### PR TITLE
Add Tailwind styling with header and logo

### DIFF
--- a/src/CarDetail.jsx
+++ b/src/CarDetail.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useParams, Link } from 'react-router-dom';
 import { cars } from './CarList.jsx';
+import Header from './Header.jsx';
 
 export default function CarDetail() {
   const { id } = useParams();
@@ -8,19 +9,23 @@ export default function CarDetail() {
 
   if (!car) {
     return (
-      <div>
-        <h2>Auto no encontrado</h2>
-        <Link to="/">Volver</Link>
+      <div className="container mx-auto p-4">
+        <Header />
+        <h2 className="text-2xl font-bold mb-4">Auto no encontrado</h2>
+        <Link to="/" className="text-blue-500 hover:underline">Volver</Link>
       </div>
     );
   }
 
   return (
-    <div>
-      <h2>Detalle de {car.marca}</h2>
-      <p>Marca: {car.marca}</p>
-      <p>Precio: ${car.precio}</p>
-      <Link to="/">Volver</Link>
+    <div className="container mx-auto p-4">
+      <Header />
+      <h2 className="text-2xl font-bold mb-4">Detalle de {car.marca}</h2>
+      <div className="bg-white shadow rounded p-4">
+        <p className="mb-2"><span className="font-semibold">Marca:</span> {car.marca}</p>
+        <p className="mb-4"><span className="font-semibold">Precio:</span> ${car.precio}</p>
+        <Link to="/" className="text-blue-500 hover:underline">Volver</Link>
+      </div>
     </div>
   );
 }

--- a/src/CarList.jsx
+++ b/src/CarList.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
+import Header from './Header.jsx';
 
 export const cars = [
   { id: 1, marca: 'Toyota', precio: 10000 },
@@ -9,15 +10,29 @@ export const cars = [
 
 export default function CarList() {
   return (
-    <div>
-      <h2>Lista de Autos</h2>
-      <ul>
-        {cars.map(car => (
-          <li key={car.id}>
-            <Link to={`/auto/${car.id}`}>{car.marca} - ${car.precio}</Link>
-          </li>
-        ))}
-      </ul>
+    <div className="container mx-auto p-4">
+      <Header />
+      <h2 className="text-2xl font-bold mb-4">Lista de Autos</h2>
+      <table className="min-w-full border-collapse">
+        <thead>
+          <tr>
+            <th className="border-b p-2 text-left">Marca</th>
+            <th className="border-b p-2 text-left">Precio</th>
+            <th className="border-b p-2"></th>
+          </tr>
+        </thead>
+        <tbody>
+          {cars.map(car => (
+            <tr key={car.id} className="hover:bg-gray-50">
+              <td className="border-b p-2">{car.marca}</td>
+              <td className="border-b p-2">${car.precio}</td>
+              <td className="border-b p-2">
+                <Link to={`/auto/${car.id}`} className="text-blue-500 hover:underline">Ver detalle</Link>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
     </div>
   );
 }

--- a/src/Header.jsx
+++ b/src/Header.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import logo from './logo.svg';
+
+export default function Header() {
+  return (
+    <header className="bg-gray-800 text-white">
+      <div className="container mx-auto flex items-center p-4">
+        <img src={logo} alt="Logo" className="h-8 w-8 mr-2" />
+        <Link to="/" className="text-xl font-bold">Autos</Link>
+      </div>
+    </header>
+  );
+}

--- a/src/index.html
+++ b/src/index.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>React Basico</title>
+  <script src="https://cdn.tailwindcss.com"></script>
 </head>
 <body>
   <div id="root"></div>

--- a/src/logo.svg
+++ b/src/logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" fill="currentColor">
+  <circle cx="50" cy="50" r="45" stroke="black" stroke-width="5" fill="#4F46E5" />
+  <text x="50" y="57" font-size="40" text-anchor="middle" fill="white" font-family="Arial, sans-serif">A</text>
+</svg>


### PR DESCRIPTION
## Summary
- integrate Tailwind via CDN
- create a reusable `Header` with a logo
- display car list in a table and add styling
- style car detail page

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_683f98d265008333ae4b893767c932e9